### PR TITLE
Fix memory leak

### DIFF
--- a/c_src/xxhash_nif.c
+++ b/c_src/xxhash_nif.c
@@ -77,6 +77,7 @@ nif_hash32_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   }
   XXH32_reset(state, seed);
   term = enif_make_resource(env, state);
+  enif_release_resource(state);
   return term;
 }
 
@@ -137,6 +138,7 @@ nif_hash64_init(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   }
   XXH64_reset(state, seed);
   term = enif_make_resource(env, state);
+  enif_release_resource(state);
   return term;
 }
 


### PR DESCRIPTION
An enif_release_resource must correspond to each enif_alloc_resource.