### PR TITLE
Fix erlang noshell eval command to get path in otp26

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -5,9 +5,9 @@ BASEDIR := $(abspath $(CURDIR)/..)
 
 PROJECT = xxhash
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s init stop)
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)])." -s init stop)
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)])." -s init stop)
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so


### PR DESCRIPTION
For OTP 26, the `erlang noshell eval` command may run into trouble with OTP26. 
You can see these errors below. To fix it, we need to change the position of `-s init stop`

```
Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).

Error! Failed to eval: io:format("~s", [code:lib_dir(erl_interface, include)]).
```

Similar issue can be found here: https://github.com/erlang/otp/issues/6916
